### PR TITLE
Turns on monospaced digits so the clock doesn't jump all over the place.

### DIFF
--- a/MenubarlessClock/MBLCAppDelegate.m
+++ b/MenubarlessClock/MBLCAppDelegate.m
@@ -73,6 +73,7 @@
 	NSTimer*	clockTimer = [NSTimer scheduledTimerWithTimeInterval: self.showSeconds ? 1.0 : 60.0 target: self selector: @selector(updateClock:) userInfo: nil repeats: YES];
 	[clockTimer setFireDate: [NSDate date]];
 	self.window.level = NSMainMenuWindowLevel;
+	self.window.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces;
 	self.window.opaque = NO;
 	[self.window orderFront: self];
 	self.window.animator.alphaValue = 1.0;

--- a/MenubarlessClock/MBLCAppDelegate.m
+++ b/MenubarlessClock/MBLCAppDelegate.m
@@ -22,7 +22,7 @@
 	[[NSColor clearColor] set];
 	NSRectFill(self.bounds);
 	
-	[[NSColor colorWithWhite: 0.0 alpha: 0.7] set];
+	[self.window.backgroundColor set];
 	CGFloat		cornerRadius = 6;
 	NSRect		bezelBox = self.bounds;
 	bezelBox.size.height += cornerRadius;
@@ -83,6 +83,9 @@
 		NSFont *monospaceFont = [NSFont monospacedDigitSystemFontOfSize:14.0 weight:NSFontWeightRegular];
 		self.timeField.font = monospaceFont;
 	}
+	
+	[NSDistributedNotificationCenter.defaultCenter addObserver:self selector:@selector(adaptUIToDarkMode) name:@"AppleInterfaceThemeChangedNotification" object:nil];
+	[self adaptUIToDarkMode];
 }
 
 
@@ -118,6 +121,29 @@
 		NSInteger	seconds = [sGregorianCalendar component: NSCalendarUnitSecond fromDate: currentTime];
 		NSDate*		nextFullMinuteFireTime = [sGregorianCalendar dateByAddingUnit: NSCalendarUnitSecond value: 60.0 -seconds toDate: currentTime options: 0];
 		[sender setFireDate: nextFullMinuteFireTime];
+	}
+}
+
+
+- (BOOL)	darkModeEnabled
+{
+	NSDictionary *dict = [NSUserDefaults.standardUserDefaults persistentDomainForName:NSGlobalDomain];
+	id style = [dict objectForKey:@"AppleInterfaceStyle"];
+	return ( style && [style isKindOfClass:NSString.class] && NSOrderedSame == [style caseInsensitiveCompare:@"dark"] );
+}
+
+
+- (void)	adaptUIToDarkMode
+{
+	if (self.darkModeEnabled)
+	{
+		self.window.backgroundColor = [NSColor colorWithWhite: 0.0 alpha: 0.7];
+		self.timeField.textColor = [NSColor whiteColor];
+	}
+	else
+	{
+		self.window.backgroundColor = [NSColor colorWithWhite: 1.0 alpha: 0.9];
+		self.timeField.textColor = [NSColor blackColor];
 	}
 }
 

--- a/MenubarlessClock/MBLCAppDelegate.m
+++ b/MenubarlessClock/MBLCAppDelegate.m
@@ -76,6 +76,12 @@
 	self.window.opaque = NO;
 	[self.window orderFront: self];
 	self.window.animator.alphaValue = 1.0;
+	
+	if ([NSFont.class respondsToSelector:@selector(monospacedDigitSystemFontOfSize:weight:)])
+	{
+		NSFont *monospaceFont = [NSFont monospacedDigitSystemFontOfSize:14.0 weight:NSFontWeightRegular];
+		self.timeField.font = monospaceFont;
+	}
 }
 
 


### PR DESCRIPTION
On supported systems (10.11+) the system font (San Francisco) can be configured to use monospaced digits. This causes the numbers to be at the same position regardless of what time it is.
