### PR TITLE
Make clock visible on all spaces

### DIFF
--- a/MenubarlessClock/MBLCAppDelegate.m
+++ b/MenubarlessClock/MBLCAppDelegate.m
@@ -76,6 +76,7 @@
 	self.window.opaque = NO;
 	[self.window orderFront: self];
 	self.window.animator.alphaValue = 1.0;
+	[self.window setCollectionBehavior: NSWindowCollectionBehaviorCanJoinAllSpaces];
 }
 
 


### PR DESCRIPTION
Currently, the clock may not be shown on some spaces. This commit ensures that the clock is visible on all spaces.
